### PR TITLE
Dixa tasks

### DIFF
--- a/analytics/src/main/scala/com/dixa/analytics/Processor.scala
+++ b/analytics/src/main/scala/com/dixa/analytics/Processor.scala
@@ -11,5 +11,6 @@ object Processor:
       case ActionType.Insert(event) =>
         event match
           case conversation: Conversation => fs2.Stream.eval(database.insert(conversation))
+          case message: Message           => fs2.Stream.eval(database.insert(message))
           case _                          => fs2.Stream.empty
       case _ => fs2.Stream.empty

--- a/analytics/src/main/scala/com/dixa/analytics/Processor.scala
+++ b/analytics/src/main/scala/com/dixa/analytics/Processor.scala
@@ -10,7 +10,12 @@ object Processor:
     events.flatMap:
       case ActionType.Insert(event) =>
         event match
-          case conversation: Conversation => fs2.Stream.eval(database.insert(conversation))
-          case message: Message           => fs2.Stream.eval(database.insert(message))
-          case _                          => fs2.Stream.empty
-      case _ => fs2.Stream.empty
+          case conversation: Conversation       => fs2.Stream.eval(database.insert(conversation))
+          case conversationTag: ConversationTag => fs2.Stream.eval(database.insert(conversationTag))
+          case message: Message                 => fs2.Stream.eval(database.insert(message))
+          case _                                => fs2.Stream.empty
+      case ActionType.Delete(event) =>
+        event match
+          case conversationTag: ConversationTag => fs2.Stream.eval(database.delete(conversationTag))
+          case _                                => fs2.Stream.empty
+      case _                        => fs2.Stream.empty

--- a/analytics/src/main/scala/com/dixa/analytics/Processor.scala
+++ b/analytics/src/main/scala/com/dixa/analytics/Processor.scala
@@ -10,12 +10,12 @@ object Processor:
     events.flatMap:
       case ActionType.Insert(event) =>
         event match
-          case conversation: Conversation       => fs2.Stream.eval(database.insert(conversation))
-          case conversationTag: ConversationTag => fs2.Stream.eval(database.insert(conversationTag))
-          case message: Message                 => fs2.Stream.eval(database.insert(message))
-          case _                                => fs2.Stream.empty
+          case conversation: Conversation                     => fs2.Stream.eval(database.insert(conversation))
+          case conversationTag: ConversationTag               => fs2.Stream.eval(database.insert(conversationTag))
+          case message: Message if message.body != "<masked>" => fs2.Stream.eval(database.insert(message))
+          case _                                              => fs2.Stream.empty
       case ActionType.Delete(event) =>
         event match
-          case conversationTag: ConversationTag => fs2.Stream.eval(database.delete(conversationTag))
-          case _                                => fs2.Stream.empty
+          case conversationTag: ConversationTag               => fs2.Stream.eval(database.delete(conversationTag))
+          case _                                              => fs2.Stream.empty
       case _                        => fs2.Stream.empty

--- a/analytics/src/main/scala/com/dixa/analytics/dao/AggregateQueryDao.scala
+++ b/analytics/src/main/scala/com/dixa/analytics/dao/AggregateQueryDao.scala
@@ -31,6 +31,20 @@ class AggregateQueryDao private (xa: Transactor[IO]):
       .unique
       .transact(xa)
 
+  def escalatedMessagesCount: IO[Long] =
+    fr"""SELECT COUNT(*)
+        |FROM messages
+        |INNER JOIN (SELECT messages.conversation_id, MIN(messages.created_at) as first, MAX(messages.created_at) as last
+        |FROM messages GROUP BY messages.conversation_id) grouped_messages
+        |ON messages.conversation_id=grouped_messages.conversation_id
+        |WHERE FLOOR(JULIANDAY(last) - JULIANDAY(first)) >= 1 AND messages.conversation_id NOT IN (
+        |SELECT DISTINCT conversation_id FROM messages WHERE messages.direction='outbound') AND messages.conversation_id NOT IN (
+        |SELECT DISTINCT conversation_id FROM converstaion_tags where tag_name='spam')
+        |""".stripMargin
+      .query[Long]
+      .unique
+      .transact(xa)
+
 object AggregateQueryDao:
 
   def create: Resource[IO, AggregateQueryDao] = Database.create().map(AggregateQueryDao(_))

--- a/analytics/src/main/scala/com/dixa/analytics/dao/AggregateQueryDao.scala
+++ b/analytics/src/main/scala/com/dixa/analytics/dao/AggregateQueryDao.scala
@@ -13,6 +13,18 @@ class AggregateQueryDao private (xa: Transactor[IO]):
       .unique
       .transact(xa)
 
+  def messagesCount: IO[Long] =
+    fr"""SELECT COUNT(*) FROM messages"""
+      .query[Long]
+      .unique
+      .transact(xa)
+
+  def maskedMessagesCount: IO[Long] =
+    fr"""SELECT COUNT(*) FROM messages WHERE body='<masked>'"""
+      .query[Long]
+      .unique
+      .transact(xa)
+
 object AggregateQueryDao:
 
   def create: Resource[IO, AggregateQueryDao] = Database.create().map(AggregateQueryDao(_))

--- a/analytics/src/main/scala/com/dixa/analytics/dao/AggregateQueryDao.scala
+++ b/analytics/src/main/scala/com/dixa/analytics/dao/AggregateQueryDao.scala
@@ -14,7 +14,7 @@ class AggregateQueryDao private (xa: Transactor[IO]):
       .transact(xa)
 
   def conversationTagsCount: IO[Long] =
-    fr"""SELECT COUNT(*) FROM converstaion_tags"""
+    fr"""SELECT COUNT(*) FROM conversation_tags"""
       .query[Long]
       .unique
       .transact(xa)
@@ -32,14 +32,35 @@ class AggregateQueryDao private (xa: Transactor[IO]):
       .transact(xa)
 
   def escalatedMessagesCount: IO[Long] =
-    fr"""SELECT COUNT(*)
-        |FROM messages
-        |INNER JOIN (SELECT messages.conversation_id, MIN(messages.created_at) as first, MAX(messages.created_at) as last
-        |FROM messages GROUP BY messages.conversation_id) grouped_messages
-        |ON messages.conversation_id=grouped_messages.conversation_id
-        |WHERE FLOOR(JULIANDAY(last) - JULIANDAY(first)) >= 1 AND messages.conversation_id NOT IN (
-        |SELECT DISTINCT conversation_id FROM messages WHERE messages.direction='outbound') AND messages.conversation_id NOT IN (
-        |SELECT DISTINCT conversation_id FROM converstaion_tags where tag_name='spam')
+    fr"""WITH non_spam_conversations AS (
+        | SELECT conversation_id FROM conversation_tags WHERE tag_name != 'spam'),
+        |
+        |inbound_messages AS (
+        | SELECT id, created_at, conversation_id FROM messages m
+        | WHERE direction='inbound' AND conversation_id IN (SELECT conversation_id FROM non_spam_conversations)),
+        |
+        |ranked_messages AS (
+        | SELECT
+        |   id,
+        |   created_at,
+        |   conversation_id,
+        |   LAG(created_at) OVER (PARTITION BY conversation_id ORDER BY created_at) AS prev_created_at
+        | FROM inbound_messages),
+        |
+        |valid_messages AS (
+        | SELECT *
+        | FROM ranked_messages rm
+        | WHERE rm.prev_created_at IS NULL
+        |   OR (
+        |     FLOOR(julianday(rm.created_at) - julianday(rm.prev_created_at)) >= 1
+        |     AND NOT EXISTS (
+        |       SELECT 1 FROM messages o
+        |       WHERE o.direction = 'outbound'
+        |         AND o.conversation_id = rm.conversation_id
+        |         AND o.created_at > rm.prev_created_at
+        |         AND o.created_at < rm.created_at)))
+        |
+        |SELECT COUNT(DISTINCT conversation_id) AS valid_conversation_count FROM valid_messages;
         |""".stripMargin
       .query[Long]
       .unique

--- a/analytics/src/main/scala/com/dixa/analytics/dao/AggregateQueryDao.scala
+++ b/analytics/src/main/scala/com/dixa/analytics/dao/AggregateQueryDao.scala
@@ -13,6 +13,12 @@ class AggregateQueryDao private (xa: Transactor[IO]):
       .unique
       .transact(xa)
 
+  def conversationTagsCount: IO[Long] =
+    fr"""SELECT COUNT(*) FROM converstaion_tags"""
+      .query[Long]
+      .unique
+      .transact(xa)
+
   def messagesCount: IO[Long] =
     fr"""SELECT COUNT(*) FROM messages"""
       .query[Long]

--- a/analytics/src/main/scala/com/dixa/analytics/dao/Database.scala
+++ b/analytics/src/main/scala/com/dixa/analytics/dao/Database.scala
@@ -47,7 +47,7 @@ object Database:
         |)""".stripMargin.update.run.transact(xa)
 
   private def createConversationTagTable(xa: Transactor[IO]): IO[Int] =
-    fr"""CREATE TABLE IF NOT EXISTS converstaion_tags (
+    fr"""CREATE TABLE IF NOT EXISTS conversation_tags (
         |  tag_id UUID NOT NULL,
         |  created_at TIMESTAMP NOT NULL,
         |  conversation_id INTEGER NOT NULL,

--- a/analytics/src/main/scala/com/dixa/analytics/dao/Database.scala
+++ b/analytics/src/main/scala/com/dixa/analytics/dao/Database.scala
@@ -46,6 +46,17 @@ object Database:
         |  assignee UUID
         |)""".stripMargin.update.run.transact(xa)
 
+  private def createConversationTagTable(xa: Transactor[IO]): IO[Int] =
+    fr"""CREATE TABLE IF NOT EXISTS converstaion_tags (
+        |  tag_id UUID NOT NULL,
+        |  created_at TIMESTAMP NOT NULL,
+        |  conversation_id INTEGER NOT NULL,
+        |  tag_name TEXT NOT NULL,
+        |
+        |  PRIMARY KEY (tag_id, conversation_id),
+        |  FOREIGN KEY (conversation_id) REFERENCES conversations(id)
+        |)""".stripMargin.update.run.transact(xa)
+
   private def createMessageTable(xa: Transactor[IO]): IO[Int] =
     fr"""CREATE TABLE IF NOT EXISTS messages (
         |  id INTEGER NOT NULL,
@@ -61,5 +72,6 @@ object Database:
 
   private def createTables(xa: Transactor[IO]): IO[Unit] = for {
     _ <- createConversationTable(xa)
+    _ <- createConversationTagTable(xa)
     _ <- createMessageTable(xa)
   } yield ()

--- a/analytics/src/main/scala/com/dixa/analytics/dao/IngestionDao.scala
+++ b/analytics/src/main/scala/com/dixa/analytics/dao/IngestionDao.scala
@@ -30,7 +30,7 @@ class IngestionDao(xa: Transactor[IO]):
       }
 
   def insert(conversationTag: ConversationTag): IO[Int] =
-    fr"""INSERT INTO converstaion_tags (tag_id, created_at, conversation_id, tag_name)
+    fr"""INSERT INTO conversation_tags (tag_id, created_at, conversation_id, tag_name)
         |VALUES (
         |  ${conversationTag.tagId},
         |  ${conversationTag.createdAt},
@@ -58,7 +58,7 @@ class IngestionDao(xa: Transactor[IO]):
       }
 
   def delete(conversationTag: ConversationTag): IO[Int] =
-    fr"""DELETE FROM converstaion_tags
+    fr"""DELETE FROM conversation_tags
         |WHERE tag_id = ${conversationTag.tagId}
         |AND conversation_id = ${conversationTag.conversationId}
         |""".stripMargin.update.run

--- a/analytics/src/main/scala/com/dixa/analytics/dao/IngestionDao.scala
+++ b/analytics/src/main/scala/com/dixa/analytics/dao/IngestionDao.scala
@@ -29,6 +29,19 @@ class IngestionDao(xa: Transactor[IO]):
         logger.error(s"Failed to insert conversation: $conversation. SqlState: $sqlState") *> IO.pure(0)
       }
 
+  def insert(conversationTag: ConversationTag): IO[Int] =
+    fr"""INSERT INTO converstaion_tags (tag_id, created_at, conversation_id, tag_name)
+        |VALUES (
+        |  ${conversationTag.tagId},
+        |  ${conversationTag.createdAt},
+        |  ${conversationTag.conversationId},
+        |  ${conversationTag.tagName}
+        |) ON CONFLICT DO NOTHING""".stripMargin.update.run
+      .transact(xa)
+      .exceptSqlState { sqlState =>
+        logger.error(s"Failed to insert conversation_tag: $conversationTag. SqlState: $sqlState") *> IO.pure(0)
+      }
+
   def insert(message: Message): IO[Int] =
     fr"""INSERT INTO messages (id, conversation_id, created_at, direction, body, author)
         |VALUES (
@@ -41,7 +54,17 @@ class IngestionDao(xa: Transactor[IO]):
         |) ON CONFLICT DO NOTHING""".stripMargin.update.run
       .transact(xa)
       .exceptSqlState { sqlState =>
-        logger.error(s"Failed to insert conversation: $message. SqlState: $sqlState") *> IO.pure(0)
+        logger.error(s"Failed to insert message: $message. SqlState: $sqlState") *> IO.pure(0)
+      }
+
+  def delete(conversationTag: ConversationTag): IO[Int] =
+    fr"""DELETE FROM converstaion_tags
+        |WHERE tag_id = ${conversationTag.tagId}
+        |AND conversation_id = ${conversationTag.conversationId}
+        |""".stripMargin.update.run
+      .transact(xa)
+      .exceptSqlState { sqlState =>
+        logger.error(s"Failed to insert conversation_tag: $conversationTag. SqlState: $sqlState") *> IO.pure(0)
       }
 
 object IngestionDao:

--- a/analytics/src/main/scala/com/dixa/analytics/dao/IngestionDao.scala
+++ b/analytics/src/main/scala/com/dixa/analytics/dao/IngestionDao.scala
@@ -29,6 +29,21 @@ class IngestionDao(xa: Transactor[IO]):
         logger.error(s"Failed to insert conversation: $conversation. SqlState: $sqlState") *> IO.pure(0)
       }
 
+  def insert(message: Message): IO[Int] =
+    fr"""INSERT INTO messages (id, conversation_id, created_at, direction, body, author)
+        |VALUES (
+        |  ${message.id},
+        |  ${message.conversationId},
+        |  ${message.createdAt},
+        |  ${message.direction},
+        |  ${message.body},
+        |  ${message.author}
+        |) ON CONFLICT DO NOTHING""".stripMargin.update.run
+      .transact(xa)
+      .exceptSqlState { sqlState =>
+        logger.error(s"Failed to insert conversation: $message. SqlState: $sqlState") *> IO.pure(0)
+      }
+
 object IngestionDao:
 
   def create: Resource[IO, IngestionDao] = Database.create(recreate = true).map(IngestionDao(_))

--- a/analytics/src/main/scala/com/dixa/analytics/generator/EventStream.scala
+++ b/analytics/src/main/scala/com/dixa/analytics/generator/EventStream.scala
@@ -31,7 +31,6 @@ object EventStream:
           .map { case (id, createdAt) =>
             generateMessage(c, id, createdAt, c.initialDirection)
           }
-          .filter(_.body != "<masked>")
           .map(Insert(_))
 
         val tags = fs2.Stream

--- a/analytics/src/main/scala/com/dixa/analytics/generator/EventStream.scala
+++ b/analytics/src/main/scala/com/dixa/analytics/generator/EventStream.scala
@@ -25,13 +25,13 @@ object EventStream:
           .fold(List.empty[(Int, Instant)]) { case (acc, id) =>
             val lastTimestamp = acc.headOption.map(_._2).getOrElse(c.createdAt)
             val nextTimestamp = lastTimestamp.plusSeconds(random.between(0, 172800)) // 0-2 days in seconds
-            (id, nextTimestamp) :: acc
+            acc :+ (id, nextTimestamp)
           }
-          .map(_.reverse) // Restore chronological order
           .flatMap(fs2.Stream.emits(_))
           .map { case (id, createdAt) =>
             generateMessage(c, id, createdAt, c.initialDirection)
           }
+          .filter(_.body != "<masked>")
           .map(Insert(_))
 
         val tags = fs2.Stream

--- a/analytics/src/test/scala/com/dixa/analytics/AggregateQueryDaoTest.scala
+++ b/analytics/src/test/scala/com/dixa/analytics/AggregateQueryDaoTest.scala
@@ -24,4 +24,8 @@ object AggregateQueryDaoTest extends IOSuite {
   test("count the number of masked messages") { db =>
     db.maskedMessagesCount.map(count => expect.same(0, count))
   }
+
+  test("count the number of escalated messages") { db =>
+    db.escalatedMessagesCount.map(count => expect(count > 0))
+  }
 }

--- a/analytics/src/test/scala/com/dixa/analytics/AggregateQueryDaoTest.scala
+++ b/analytics/src/test/scala/com/dixa/analytics/AggregateQueryDaoTest.scala
@@ -13,6 +13,10 @@ object AggregateQueryDaoTest extends IOSuite {
     db.conversationCount.map(count => expect.same(5000, count))
   }
 
+  test("count the number of conversation tags") { db =>
+    db.conversationTagsCount.map(count => expect(count > 0))
+  }
+
   test("count the number of messages") { db =>
     db.messagesCount.map(count => expect(count > 0))
   }

--- a/analytics/src/test/scala/com/dixa/analytics/AggregateQueryDaoTest.scala
+++ b/analytics/src/test/scala/com/dixa/analytics/AggregateQueryDaoTest.scala
@@ -13,4 +13,11 @@ object AggregateQueryDaoTest extends IOSuite {
     db.conversationCount.map(count => expect.same(5000, count))
   }
 
+  test("count the number of messages") { db =>
+    db.messagesCount.map(count => expect(count > 0))
+  }
+
+  test("count the number of masked messages") { db =>
+    db.maskedMessagesCount.map(count => expect.same(0, count))
+  }
 }


### PR DESCRIPTION
Some possible improvements in design:
- add indices where applicable. for example in escalated queries, adding the indices for tags in conversation_tags table would speed up the search of non_spammed queries.
- separate read and write connection pools so that multiple read operations can be done in parallel as no locking is required for reading.
- another way to improve read latencies is by adding in some replicated nodes so that read operations are held in replicas while the writes can be done in the main node.
- Analyzing the queries, especially the complex ones like escalated messages query, could help identify the slow operations.